### PR TITLE
Add upstream version argument

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,7 @@
 {
   "name": "gnosis-beacon-chain-prysm.dnp.dappnode.eth",
   "version": "0.1.0",
+  "upstreamVersion": "v2.1.1-gbc",
   "description": "Gnosis Beacon Chain (GBC) brings vital canary network functionality to the burgeoning Ethereum 2.0 ecosystem. Applications can iterate through real-world strategies, stage important applications, or choose to run DApps in a faster, lower-stakes environment while enjoying the benefits of massive scalability. This package includes a Prysm validator client to validate the PoS chain",
   "shortDescription":"Gnosis Beacon Chain node + validator",
   "type": "service",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,8 @@ services:
     image: "beacon-chain.gnosis-beacon-chain-prysm.dnp.dappnode.eth:0.1.0"
     build:
       context: beacon-chain
+      args:
+        UPSTREAM_VERSION: v2.1.1
     volumes:
       - "beacon-chain-data:/data"
     ports:
@@ -19,6 +21,8 @@ services:
     image: "validator.gnosis-beacon-chain-prysm.dnp.dappnode.eth:0.1.0"
     build:
       context: validator
+      args:
+        UPSTREAM_VERSION: v2.1.1-gbc
     volumes:
       - "validator-data:/root/"
     restart: unless-stopped


### PR DESCRIPTION
Add the argument upstream version. It was not completely set up because gnosis chain prysm client does not publish the releases of the client. So this update is to add the value visually in the UI.