### PR TITLE
Set minimum dappnode version

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/dappnode/DAppNodePackage-Gnosis-Beacon-Chain-Prysm/issues"
   },
   "requirements": {
-    "minimumDappnodeVersion": "0.2.51"
+    "minimumDappnodeVersion": "0.2.56"
   },
   "backup": [
     {


### PR DESCRIPTION
Set the requirement to have the core release 0.2.56 to install prysm gnosis