### PR TITLE
Remove checkpoint sync

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -4,10 +4,6 @@ if [[ -n $WEB3_BACKUP ]] && [[ $EXTRA_OPTS != *"--fallback-web3provider"* ]]; th
   EXTRA_OPTS="--fallback-web3provider=${WEB3_BACKUP} ${EXTRA_OPTS}"
 fi
 
-if [[ -n $CHECKPOINT_SYNC_URL ]]; then
-  EXTRA_OPTS="--checkpoint-sync-url=${CHECKPOINT_SYNC_URL} --genesis-beacon-api-url=${CHECKPOINT_SYNC_URL} ${EXTRA_OPTS}"
-fi
-
 exec -c beacon-chain \
   --datadir=/data \
   --rpc-host=0.0.0.0 \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,6 @@ services:
       - "13000"
     restart: unless-stopped
     environment:
-      CHECKPOINT_SYNC_URL: ""
       WEB3_BACKUP: "https://rpc.gnosischain.com/"
       HTTP_WEB3PROVIDER: "http://nethermind-xdai.dappnode:8545"
       CORSDOMAIN: "http://gnosis-beacon-chain-prysm.dappnode"
@@ -33,7 +32,7 @@ services:
       BEACON_RPC_GATEWAY_PROVIDER: "beacon-chain.gnosis-beacon-chain-prysm.dappnode:3500"
       GRAFFITI: validating_from_DAppNode
       EXTRA_OPTS: ""
-      FEE_RECIPIENT_ADDRESS: ""      
+      FEE_RECIPIENT_ADDRESS: ""
 volumes:
   beacon-chain-data: {}
   validator-data: {}

--- a/setup-wizard.yml
+++ b/setup-wizard.yml
@@ -28,16 +28,6 @@ fields:
     description: >-
       It's a good idea to add a backup web3 provider in case your main one goes down. You can use the official one: **https://rpc.gnosischain.com/**
     required: false
-  - id: checkpointSyncUrl
-    target:
-      type: environment
-      name: CHECKPOINT_SYNC_URL
-      service: beacon-chain
-    title: Checkpoint for fast sync
-    description: >-
-      To get Prysm up and running in only a few minutes, you can start Prysm from a recent finalized checkpoint state rather than syncing from genesis. This is substantially **faster** and consumes **less resources** than syncing from genesis, while still providing all the same features. Be sure you are using a trusted node for the fast sync.
-      Get your checkpoint sync from a running gnosis beacon chain node or use the official one **https://rpc-gbc.gnosischain.com/**
-    required: false
   - id: feeRecipientAddress
     target:
       type: environment


### PR DESCRIPTION
Checkpoint sync provideded by gnosis chain is not working with Prysm. Upstream issue https://github.com/prysmaticlabs/prysm/issues/10832
- Prysm is trying to fetch method not allowed by the RPC exposed by gnosis: `https://rpc-gbc.gnosischain.com/eth/v1/beacon/weak_subjectivity`
```
{"code":405,"message":"METHOD_NOT_ALLOWED","stacktraces":[]}
```
- Prysm is keeping in an exit loop if the checkpoint sync fails, not allowing the beacon chain to keep syncing

Remove it until got fixed.

See the error at https://github.com/dappnode/DAppNodePackage-gnosis-beacon-chain-prysm/issues/15