### PR TITLE
Port standardization

### DIFF
--- a/beacon-chain/entrypoint.sh
+++ b/beacon-chain/entrypoint.sh
@@ -10,6 +10,8 @@ exec -c beacon-chain \
   --grpc-gateway-host=0.0.0.0 \
   --monitoring-host=0.0.0.0 \
   --p2p-local-ip=0.0.0.0 \
+  --p2p-tcp-port=$P2P_TCP_PORT \
+  --p2p-udp-port=$P2P_UDP_PORT \
   --http-web3provider=$HTTP_WEB3PROVIDER \
   --grpc-gateway-port=3500 \
   --grpc-gateway-corsdomain=$CORSDOMAIN \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     volumes:
       - "beacon-chain-data:/data"
     ports:
-      - "12000/udp"
-      - "13000/tcp"
+      - "12004:12004/udp"
+      - "13004:13004/tcp"
     restart: unless-stopped
     environment:
       XDAI_RPC_URL: "https://rpc.gnosischain.com/"
@@ -18,6 +18,8 @@ services:
       HTTP_WEB3PROVIDER: "http://nethermind-xdai.dappnode:8545"
       CORSDOMAIN: "http://gnosis-beacon-chain-prysm.dappnode"
       DEPLOYMENT_BLOCK: 19469077
+      P2P_TCP_PORT: 13004
+      P2P_UDP_PORT: 12004
       EXTRA_OPTS: ""
   validator:
     image: "validator.gnosis-beacon-chain-prysm.dnp.dappnode.eth:0.1.0"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - "beacon-chain-data:/data"
     ports:
-      - "12004:12004/udp"
+      - "13003:13003/udp"
       - "14003:14003/tcp"
     restart: unless-stopped
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       - "beacon-chain-data:/data"
     ports:
       - "12004:12004/udp"
-      - "13004:13004/tcp"
+      - "14003:14003/tcp"
     restart: unless-stopped
     environment:
       XDAI_RPC_URL: "https://rpc.gnosischain.com/"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       HTTP_WEB3PROVIDER: "http://nethermind-xdai.dappnode:8545"
       CORSDOMAIN: "http://gnosis-beacon-chain-prysm.dappnode"
       DEPLOYMENT_BLOCK: 19469077
-      P2P_TCP_PORT: 13004
+      P2P_TCP_PORT: 14003
       P2P_UDP_PORT: 13003
       EXTRA_OPTS: ""
   validator:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,7 +19,7 @@ services:
       CORSDOMAIN: "http://gnosis-beacon-chain-prysm.dappnode"
       DEPLOYMENT_BLOCK: 19469077
       P2P_TCP_PORT: 13004
-      P2P_UDP_PORT: 12004
+      P2P_UDP_PORT: 13003
       EXTRA_OPTS: ""
   validator:
     image: "validator.gnosis-beacon-chain-prysm.dnp.dappnode.eth:0.1.0"


### PR DESCRIPTION
According to this issue https://github.com/dappnode/DAppNode/issues/457
We are selecting the host port for the client.

In prysm client you can change these default ports using these flags:
```
   --p2p-tcp-port value            The port used by libp2p. (default: 13000)
   --p2p-udp-port value            The port used by discv5. (default: 12000)
```