### PR TITLE
Add slashing-prune script

### DIFF
--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,3 +1,5 @@
+ARG UPSTREAM_VERSION
+
 ###############
 # Prune image #
 ###############
@@ -10,7 +12,6 @@ RUN apk update && apk add git && git clone https://github.com/dappnode/prune-sla
 ##############
 # Base image #
 ##############
-ARG UPSTREAM_VERSION
 FROM ghcr.io/gnosischain/gbc-prysm-validator:${UPSTREAM_VERSION}-gbc as base
 
 ################

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -1,3 +1,12 @@
+###############
+# Prune image #
+###############
+# golang alpine 1.17
+FROM golang:1.17-alpine as prune
+WORKDIR /usr/src/app
+RUN apk update && apk add git && git clone https://github.com/dappnode/prune-slashing-protection.git && \
+    go build -o slashing-prune ./prune-slashing-protection/slashing-prune.go
+
 ##############
 # Base image #
 ##############
@@ -28,6 +37,9 @@ COPY --from=base /app/cmd/validator/validator.runfiles/prysm/cmd/validator/valid
 # Prysm launch gnosis config: https://github.com/gnosischain/prysm-launch/tree/master/config
 COPY --from=config /usr/src/app/bootnodes.yaml /root/sbc/config/
 COPY --from=config /usr/src/app/config.yml /root/sbc/config/
+
+# Copy slashing prune
+COPY --from=prune slashing-prune /usr/local/bin
 
 # Prysm scripts
 COPY auth-token /auth-token

--- a/validator/Dockerfile
+++ b/validator/Dockerfile
@@ -40,7 +40,7 @@ COPY --from=config /usr/src/app/bootnodes.yaml /root/sbc/config/
 COPY --from=config /usr/src/app/config.yml /root/sbc/config/
 
 # Copy slashing prune
-COPY --from=prune slashing-prune /usr/local/bin
+COPY --from=prune /usr/src/app/slashing-prune /usr/local/bin
 
 # Prysm scripts
 COPY auth-token /auth-token

--- a/validator/eth2-migrate.sh
+++ b/validator/eth2-migrate.sh
@@ -17,6 +17,7 @@ BACKUP_DIR="${WALLET_DIR}/backup"
 BACKUP_ZIP_FILE="${BACKUP_DIR}/backup.zip"
 BACKUP_KEYSTORES_DIR="${BACKUP_DIR}/keystores" # Directory where the keystores are stored in format: keystore_0.json keystore_1.json ...
 BACKUP_SLASHING_FILE="${BACKUP_DIR}/slashing_protection.json"
+BACKUP_SLASHING_FILE_PRUNE="${BACKUP_DIR}/slashing_protection_prune.json"
 BACKUP_WALLETPASSWORD_FILE="${BACKUP_DIR}/walletpassword.txt"
 REQUEST_BODY_FILE="${BACKUP_DIR}/request_body"
 
@@ -173,6 +174,13 @@ function export_slashing_protection() {
     empty_validator_volume
     exit 1
   }
+
+  # Prune the slashing data to prevent the web3signer from crashing due to timeout
+  slashing-prune --source-path "$BACKUP_SLASHING_FILE" --target-path "$BACKUP_SLASHING_FILE_PRUNE" || {
+    echo "${ERROR} failed to export slashing protection, manual migration required. Please check https://gnosis-manual-migration.dappnode.io to get more info"
+    empty_validator_volume
+    exit 1
+  }
 }
 
 # Create request body file
@@ -185,7 +193,7 @@ function create_request_body_file() {
     echo $(jq --slurpfile keystore ${KEYSTORE_FILE} '.keystores += [$keystore[0]|tojson]' ${REQUEST_BODY_FILE}) >${REQUEST_BODY_FILE}
     echo $(jq --arg walletpassword "$(cat ${BACKUP_WALLETPASSWORD_FILE})" '.passwords += [$walletpassword]' ${REQUEST_BODY_FILE}) >${REQUEST_BODY_FILE}
   done
-  echo $(jq --slurpfile slashing $BACKUP_SLASHING_FILE '.slashing_protection |= [$slashing[0]|tojson][0]' $REQUEST_BODY_FILE) >${REQUEST_BODY_FILE}
+  echo $(jq --slurpfile slashing $BACKUP_SLASHING_FILE_PRUNE '.slashing_protection |= [$slashing[0]|tojson][0]' $REQUEST_BODY_FILE) >${REQUEST_BODY_FILE}
 }
 
 # Import validators with request body file


### PR DESCRIPTION
Prune the slashing data before doing the import in the web3signer. This will decrease significative the slashing size and prevent the web3signer from crashing due to timeouts errors