### PR TITLE
Downgrade to 2.1.2

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "gnosis-beacon-chain-prysm.dnp.dappnode.eth",
   "version": "1.0.0",
-  "upstreamVersion": "v2.1.4",
+  "upstreamVersion": "v2.1.2",
   "upstreamRepo": "prysmaticlabs/prysm",
   "upstreamArg": "UPSTREAM_VERSION",
   "description": "Gnosis Beacon Chain (GBC) brings vital canary network functionality to the burgeoning Ethereum 2.0 ecosystem. Applications can iterate through real-world strategies, stage important applications, or choose to run DApps in a faster, lower-stakes environment while enjoying the benefits of massive scalability. This package includes a Prysm validator client to validate the PoS chain",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: beacon-chain
       args:
-        UPSTREAM_VERSION: v2.1.4
+        UPSTREAM_VERSION: v2.1.2
     volumes:
       - "beacon-chain-data:/data"
     ports:
@@ -23,7 +23,7 @@ services:
     build:
       context: validator
       args:
-        UPSTREAM_VERSION: v2.1.4
+        UPSTREAM_VERSION: v2.1.2
     volumes:
       - "validator-data:/root/"
     restart: unless-stopped


### PR DESCRIPTION
It was a mistake to merge to the latest version, we must wait for xdai people until they publish the binary with the 2.1.4 version